### PR TITLE
fix a typo in verify.go

### DIFF
--- a/vendor/cmd/go/internal/vgo/verify.go
+++ b/vendor/cmd/go/internal/vgo/verify.go
@@ -21,7 +21,7 @@ var CmdVerify = &base.Command{
 	Run:       runVerify,
 	Short:     "verify downloaded modules against expected hashes",
 	Long: `
-Verify checks that the depdendencies of the current module,
+Verify checks that the dependencies of the current module,
 which are stored in a local downloaded source cache,
 have not been modified since being downloaded.
 


### PR DESCRIPTION
closes golang/go#24125