### PR TITLE
x/vgo: include GOPROXY in env output

### DIFF
--- a/vendor/cmd/go/internal/envcmd/env.go
+++ b/vendor/cmd/go/internal/envcmd/env.go
@@ -57,6 +57,7 @@ func MkEnv() []cfg.EnvVar {
 		{Name: "GOHOSTOS", Value: runtime.GOOS},
 		{Name: "GOOS", Value: cfg.Goos},
 		{Name: "GOPATH", Value: cfg.BuildContext.GOPATH},
+		{Name: "GOPROXY", Value: os.Getenv("GOPROXY")},
 		{Name: "GORACE", Value: os.Getenv("GORACE")},
 		{Name: "GOROOT", Value: cfg.GOROOT},
 		{Name: "GOTMPDIR", Value: os.Getenv("GOTMPDIR")},


### PR DESCRIPTION
While modules are usually downloaded from a package's import 
path, vgo supports setting a GOPROXY environmental value that
instructs  it to make use of a proxy server instead of the package's 
import path.

Fixes golang/go#24748